### PR TITLE
Refactor lesson and home repositories

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/repository/LessonRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/repository/LessonRepositoryImpl.kt
@@ -1,13 +1,14 @@
 package com.d4rk.englishwithlidia.plus.app.lessons.details.repository
 
-import android.app.Application
 import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.repository.LessonRepository
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui.UiLessonScreen
+import io.ktor.client.HttpClient
 
 class LessonRepositoryImpl(
-) : LessonRepository, LessonRepositoryImplementation() {
+    client: HttpClient,
+) : LessonRepository, LessonRepositoryImplementation(client) {
 
     override suspend fun getLesson(lessonId: String): UiLessonScreen {
-        return getLessonImplementation(lessonId = lessonId)
+        return invoke(lessonId = lessonId)
     }
 }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/repository/HomeRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/repository/HomeRepositoryImpl.kt
@@ -1,14 +1,12 @@
 package com.d4rk.englishwithlidia.plus.app.lessons.list.repository
 
-import android.app.Application
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui.UiHomeScreen
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.repository.HomeRepository
-import com.d4rk.englishwithlidia.plus.data.datastore.DataStore
+import io.ktor.client.HttpClient
 
 class HomeRepositoryImpl(
-    dataStore: DataStore,
-    application: Application,
-) : HomeRepository, HomeRepositoryImplementation(application, dataStore) {
+    client: HttpClient,
+) : HomeRepository, HomeRepositoryImplementation(client) {
 
     override suspend fun getHomeLessons(): UiHomeScreen {
         return getHomeLessonsImplementation()

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/repository/HomeRepositoryImplementation.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/repository/HomeRepositoryImplementation.kt
@@ -1,23 +1,18 @@
 package com.d4rk.englishwithlidia.plus.app.lessons.list.repository
 
-import android.app.Application
 import com.d4rk.englishwithlidia.plus.BuildConfig
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui.UiHomeLesson
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui.UiHomeScreen
 import com.d4rk.englishwithlidia.plus.core.domain.model.api.ApiHomeResponse
 import com.d4rk.englishwithlidia.plus.core.utils.constants.api.ApiConstants
-import com.d4rk.englishwithlidia.plus.data.core.AppCoreManager
-import com.d4rk.englishwithlidia.plus.data.datastore.DataStore
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import kotlinx.serialization.json.Json
 
 abstract class HomeRepositoryImplementation(
-    val application : Application ,
-    val dataStore : DataStore ,
+    private val client: HttpClient,
 ) {
-    private val client : HttpClient = AppCoreManager.ktorClient
 
     private val baseUrl = BuildConfig.DEBUG.let { isDebug ->
         val environment = if (isDebug) "debug" else "release"
@@ -31,30 +26,22 @@ abstract class HomeRepositoryImplementation(
 
     suspend fun getHomeLessonsImplementation() : UiHomeScreen {
         return runCatching {
-            val response = client.get(baseUrl)
-            val jsonString = response.bodyAsText()
-
+            val jsonString = client.get(baseUrl).bodyAsText()
             val lessons = jsonString.takeUnless { it.isBlank() }
-                    ?.let { jsonParser.decodeFromString<ApiHomeResponse>(it) }
-                    ?.takeIf { it.data.isNotEmpty() }?.data?.mapNotNull { networkLesson ->
-                        println("English with Lidia Plus -> Fetched lesson: $networkLesson")
-                        runCatching {
-                            UiHomeLesson(
-                                lessonId = networkLesson.lessonId ,
-                                lessonTitle = networkLesson.lessonTitle ,
-                                lessonType = networkLesson.lessonType ,
-                                lessonThumbnailImageUrl = networkLesson.lessonThumbnailImageUrl ,
-                                lessonDeepLinkPath = networkLesson.lessonDeepLinkPath
-                            )
-                        }.getOrNull()
-                    }?.also { lessons ->
-                        println("English with Lidia Plus -> Fetched ${lessons.size} lessons")
-                    } ?: emptyList()
+                ?.let { jsonParser.decodeFromString<ApiHomeResponse>(it) }
+                ?.takeIf { it.data.isNotEmpty() }?.data?.mapNotNull { networkLesson ->
+                    UiHomeLesson(
+                        lessonId = networkLesson.lessonId,
+                        lessonTitle = networkLesson.lessonTitle,
+                        lessonType = networkLesson.lessonType,
+                        lessonThumbnailImageUrl = networkLesson.lessonThumbnailImageUrl,
+                        lessonDeepLinkPath = networkLesson.lessonDeepLinkPath,
+                    )
+                } ?: emptyList()
 
             UiHomeScreen(lessons = ArrayList(lessons))
-        }.getOrElse { exception ->
-            println("English with Lidia Plus -> Error: ${exception.message}")
-            return@getOrElse UiHomeScreen()
+        }.getOrElse {
+            UiHomeScreen()
         }
     }
 }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/core/di/modules/AppModule.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/core/di/modules/AppModule.kt
@@ -41,11 +41,11 @@ val appModule : Module = module {
     }
 
     // Lessons
-    single<HomeRepository> { HomeRepositoryImpl(dataStore = get(), application = get()) }
+    single<HomeRepository> { HomeRepositoryImpl(client = get()) }
     factory { GetHomeLessonsUseCase(repository = get()) }
     viewModel { HomeViewModel(application = get(), getHomeLessonsUseCase = get(), dispatcherProvider = get()) }
 
-    single<LessonRepository> { LessonRepositoryImpl(application = get()) }
+    single<LessonRepository> { LessonRepositoryImpl(client = get()) }
     factory { GetLessonUseCase(repository = get()) }
     viewModel { LessonViewModel(application = get(), getLessonUseCase = get(), dispatcherProvider = get()) }
 }


### PR DESCRIPTION
## Summary
- simplify `HomeRepositoryImplementation` and `HomeRepositoryImpl`
- refactor `LessonRepositoryImplementation` to behave as a use case
- inject `HttpClient` into repositories via `AppModule`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548ca19210832d8278284f9b8842eb