### PR TITLE
Add AndroidX Media3 dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -120,4 +120,8 @@ dependencies {
 
     // Wavy Slider
     implementation(dependencyNotation = libs.wavy.slider)
+
+    // AndroidX Media3 ExoPlayer
+    implementation(dependencyNotation = libs.media3.exoplayer)
+    implementation(dependencyNotation = libs.media3.ui)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,9 +5,12 @@ wavySlider = "2.0.0"
 kotlin = "2.1.21"
 google-services = "4.4.2"
 google-firebase-crashlytics = "3.0.4"
+media3 = "1.3.1"
 
 [libraries]
 wavy-slider = { module = "ir.mahozad.multiplatform:wavy-slider", version.ref = "wavySlider" }
+media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3" }
+media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add Media3 version to version catalog
- include Media3 ExoPlayer and UI libs in app dependencies

## Testing
- `bash gradlew assembleDebug -x lint --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855dc5dc288832d9c7f0f4f39104e7c