### PR TITLE
Show lesson title in Media3 notification

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.net.Uri
 import androidx.lifecycle.viewModelScope
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import com.d4rk.englishwithlidia.plus.notifications.managers.AudioPlaybackNotificationsManager
@@ -50,12 +51,20 @@ class LessonViewModel(
         }
     }
 
-    fun preparePlayer(audioUrl: String) {
+    fun preparePlayer(audioUrl: String, title: String) {
         viewModelScope.launch {
             player?.release()
             val audioUri = Uri.parse(audioUrl)
             player = ExoPlayer.Builder(getApplication()).build().apply {
-                setMediaItem(MediaItem.fromUri(audioUri))
+                val mediaItem = MediaItem.Builder()
+                    .setUri(audioUri)
+                    .setMediaMetadata(
+                        MediaMetadata.Builder()
+                            .setTitle(title)
+                            .build()
+                    )
+                    .build()
+                setMediaItem(mediaItem)
                 prepare()
                 playWhenReady = false
                 addListener(object : Player.Listener {

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/components/LessonContentLayout.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/components/LessonContentLayout.kt
@@ -85,7 +85,10 @@ fun LessonContentLayout(
                     val isPlaying = lesson.isPlaying
 
                     LaunchedEffect(key1 = contentItem.contentAudioUrl) {
-                        viewModel.preparePlayer(contentItem.contentAudioUrl)
+                        viewModel.preparePlayer(
+                            contentItem.contentAudioUrl,
+                            lesson.lessonTitle
+                        )
                     }
 
                     AudioCardView(onPlayClick = { viewModel.playPause() } ,


### PR DESCRIPTION
## Summary
- set title metadata when preparing audio player
- pass lesson title from content layout so notification displays current lesson name

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685695358dc8832db08224853ed763a0