### PR TITLE
Improve Media3 usage and prevent ANRs

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/core/utils/extensions/ListenableFutureExtensions.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/core/utils/extensions/ListenableFutureExtensions.kt
@@ -1,0 +1,18 @@
+package com.d4rk.englishwithlidia.plus.core.utils.extensions
+
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.MoreExecutors
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+suspend fun <T> ListenableFuture<T>.await(): T = suspendCancellableCoroutine { cont ->
+    this.addListener({
+        try {
+            cont.resume(this.get())
+        } catch (e: Exception) {
+            cont.resumeWithException(e)
+        }
+    }, MoreExecutors.directExecutor())
+    cont.invokeOnCancellation { this.cancel(true) }
+}


### PR DESCRIPTION
## Summary
- add helper to await ListenableFuture without blocking
- use await when building/using MediaController
- update playback progress loop to run off the main thread

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a14e0d94832dbfe3026b5048e8d3