### PR TITLE
Fix thread access when updating playback position

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonViewModel.kt
@@ -107,12 +107,17 @@ class LessonViewModel(
     private fun startPositionUpdateJob() {
         viewModelScope.launch(dispatcherProvider.default) {
             while (true) {
-                val currentPosition = player?.currentPosition ?: 0L
+                val currentPosition = withContext(dispatcherProvider.main) {
+                    player?.currentPosition ?: 0L
+                }
                 withContext(dispatcherProvider.main) {
                     updateUiState { copy(playbackPosition = currentPosition) }
                 }
                 delay(timeMillis = 100)
-                if (player?.isPlaying == false) {
+                val isPlaying = withContext(dispatcherProvider.main) {
+                    player?.isPlaying == true
+                }
+                if (!isPlaying) {
                     break
                 }
             }


### PR DESCRIPTION
## Summary
- use main dispatcher when accessing playback status in LessonViewModel

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a407c514832d998b0cea46674c70