### PR TITLE
Refactor LessonViewModel

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/domain/action/LessonAction.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/domain/action/LessonAction.kt
@@ -1,0 +1,5 @@
+package com.d4rk.englishwithlidia.plus.app.lessons.details.domain.action
+
+import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.ActionEvent
+
+sealed interface LessonAction : ActionEvent

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/domain/action/LessonEvent.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/domain/action/LessonEvent.kt
@@ -1,0 +1,7 @@
+package com.d4rk.englishwithlidia.plus.app.lessons.details.domain.action
+
+import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
+
+sealed interface LessonEvent : UiEvent {
+    data class FetchLesson(val lessonId: String) : LessonEvent
+}

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonActivity.kt
@@ -7,7 +7,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -31,11 +30,9 @@ class LessonActivity : AppCompatActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background,
                 ) {
-                    val lesson = viewModel.uiState.collectAsState()
                     LessonScreen(
                         activity = this@LessonActivity,
                         viewModel = viewModel,
-                        lesson = lesson.value,
                     )
                 }
             }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonScreen.kt
@@ -6,7 +6,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
+import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
+import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
 import com.d4rk.android.libs.apptoolkit.core.ui.components.navigation.LargeTopAppBarWithScaffold
 import com.d4rk.englishwithlidia.plus.app.lessons.details.ui.components.LessonContentLayout
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui.UiLessonScreen
@@ -17,31 +20,36 @@ import com.d4rk.englishwithlidia.plus.core.data.datastore.DataStore
 fun LessonScreen(
     activity : LessonActivity ,
     viewModel : LessonViewModel ,
-    lesson : UiLessonScreen
 ) {
     val context = LocalContext.current
     val dataStore = DataStore.getInstance(context)
     val scrollState = rememberScrollState()
-    val isLoading by viewModel.isLoading.collectAsState()
+    val screenState : UiStateScreen<UiLessonScreen> by viewModel.uiState.collectAsState()
 
-    LargeTopAppBarWithScaffold (
-        title = lesson.lessonTitle ,
+    LargeTopAppBarWithScaffold(
+        title = screenState.data?.lessonTitle ?: "",
         onBackClicked = {
 
-        }) { paddingValues ->
-
-
-        if (isLoading) {
-            LoadingScreen()
         }
-        else {
-            LessonContentLayout(
-                paddingValues = paddingValues ,
-                scrollState = scrollState ,
-                dataStore = dataStore ,
-                lesson = lesson ,
-                viewModel = viewModel
-            )
-        }
+    ) { paddingValues ->
+
+        ScreenStateHandler(
+            screenState = screenState,
+            onLoading = {
+                LoadingScreen()
+            },
+            onEmpty = {
+                NoDataScreen()
+            },
+            onSuccess = { lesson ->
+                LessonContentLayout(
+                    paddingValues = paddingValues,
+                    scrollState = scrollState,
+                    dataStore = dataStore,
+                    lesson = lesson,
+                    viewModel = viewModel,
+                )
+            },
+        )
     }
 }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonViewModel.kt
@@ -5,41 +5,41 @@ import android.content.ComponentName
 import android.content.Intent
 import android.net.Uri
 import androidx.core.content.ContextCompat
-import androidx.lifecycle.viewModelScope
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.copyData
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.setLoading
+import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
+import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.action.LessonAction
+import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.action.LessonEvent
 import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.usecases.GetLessonUseCase
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui.UiLessonScreen
 import com.d4rk.englishwithlidia.plus.core.utils.extensions.await
 import com.d4rk.englishwithlidia.plus.playback.AudioPlaybackService
-import com.d4rk.englishwithlidia.plus.ui.viewmodel.BaseViewModel
 import com.google.common.util.concurrent.ListenableFuture
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 class LessonViewModel(
-    application: Application,
+    private val application: Application,
     private val getLessonUseCase: GetLessonUseCase,
     private val dispatcherProvider: DispatcherProvider,
-) : BaseViewModel(application) {
-
-    private val _uiState = MutableStateFlow(UiLessonScreen())
-    val uiState: StateFlow<UiLessonScreen> = _uiState.asStateFlow()
+) : ScreenViewModel<UiLessonScreen, LessonEvent, LessonAction>(
+    initialState = UiStateScreen(screenState = ScreenState.IsLoading(), data = UiLessonScreen())
+) {
 
     private var controllerFuture: ListenableFuture<MediaController>? = null
     private var player: Player? = null
 
     init {
-        viewModelScope.launch {
-            val context = getApplication<Application>()
+        launch {
+            val context = application
             val intent = Intent(context, AudioPlaybackService::class.java)
             ContextCompat.startForegroundService(context, intent)
             val sessionToken = SessionToken(context, ComponentName(context, AudioPlaybackService::class.java))
@@ -47,32 +47,37 @@ class LessonViewModel(
             player = controllerFuture?.await()
             player?.addListener(object : Player.Listener {
                 override fun onIsPlayingChanged(isPlaying: Boolean) {
-                    updateUiState { copy(isPlaying = isPlaying) }
+                    screenState.copyData { copy(isPlaying = isPlaying) }
                 }
 
-                    override fun onPlaybackStateChanged(playbackState: Int) {
-                        if (playbackState == Player.STATE_READY) {
-                            val duration = player?.duration ?: 0L
-                            updateUiState { copy(playbackDuration = duration) }
-                        }
+                override fun onPlaybackStateChanged(playbackState: Int) {
+                    if (playbackState == Player.STATE_READY) {
+                        val duration = player?.duration ?: 0L
+                        screenState.copyData { copy(playbackDuration = duration) }
                     }
-                })
+                }
+            })
         }
     }
 
     fun getLesson(lessonId: String) {
-        viewModelScope.launch(coroutineExceptionHandler + dispatcherProvider.io) {
-            showLoading()
+        onEvent(LessonEvent.FetchLesson(lessonId))
+    }
+
+    private fun fetchLesson(lessonId: String) {
+        launch(context = dispatcherProvider.io) {
+            screenState.setLoading<UiLessonScreen>()
             val lesson = getLessonUseCase(lessonId)
             withContext(dispatcherProvider.main) {
-                _uiState.value = lesson
-                hideLoading()
+                screenState.update { current ->
+                    current.copy(screenState = ScreenState.Success(), data = lesson)
+                }
             }
         }
     }
 
     fun preparePlayer(audioUrl: String, title: String) {
-        viewModelScope.launch {
+        launch {
             controllerFuture?.await()?.let { controller ->
                 val mediaItem = MediaItem.Builder()
                     .setUri(Uri.parse(audioUrl))
@@ -87,6 +92,12 @@ class LessonViewModel(
                 controller.playWhenReady = false
             }
             startPositionUpdateJob()
+        }
+    }
+
+    override fun onEvent(event: LessonEvent) {
+        when (event) {
+            is LessonEvent.FetchLesson -> fetchLesson(event.lessonId)
         }
     }
 
@@ -105,13 +116,13 @@ class LessonViewModel(
     }
 
     private fun startPositionUpdateJob() {
-        viewModelScope.launch(dispatcherProvider.default) {
+        launch(context = dispatcherProvider.default) {
             while (true) {
                 val currentPosition = withContext(dispatcherProvider.main) {
                     player?.currentPosition ?: 0L
                 }
                 withContext(dispatcherProvider.main) {
-                    updateUiState { copy(playbackPosition = currentPosition) }
+                    screenState.copyData { copy(playbackPosition = currentPosition) }
                 }
                 delay(timeMillis = 100)
                 val isPlaying = withContext(dispatcherProvider.main) {
@@ -122,10 +133,6 @@ class LessonViewModel(
                 }
             }
         }
-    }
-
-    private fun updateUiState(update: UiLessonScreen.() -> UiLessonScreen) {
-        _uiState.value = _uiState.value.update()
     }
 
     override fun onCleared() {


### PR DESCRIPTION
## Summary
- migrate LessonViewModel to ScreenViewModel pattern
- add LessonEvent and LessonAction
- update LessonActivity and LessonScreen to use new screen state API

## Testing
- `./gradlew --no-daemon tasks --all`
- `./gradlew --no-daemon lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a871721c832d9853d94ddcc2de9b