### PR TITLE
Add thumbnail field for lesson audio

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/data/LessonRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/data/LessonRepositoryImpl.kt
@@ -43,6 +43,7 @@ class LessonRepositoryImpl(
                                     contentText = networkContent.contentText,
                                     contentAudioUrl = networkContent.contentAudioUrl,
                                     contentImageUrl = networkContent.contentImageUrl,
+                                    contentThumbnailUrl = networkContent.contentThumbnailUrl,
                                 )
                             },
                         ),

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonViewModel.kt
@@ -84,7 +84,7 @@ class LessonViewModel(
         }
     }
 
-    fun preparePlayer(audioUrl: String, title: String) {
+    fun preparePlayer(audioUrl: String, title: String, thumbnailUrl: String? = null) {
         launch {
             controllerFuture?.await()?.let { controller ->
                 val mediaItem = MediaItem.Builder()
@@ -92,6 +92,11 @@ class LessonViewModel(
                     .setMediaMetadata(
                         MediaMetadata.Builder()
                             .setTitle(title)
+                            .apply {
+                                if (!thumbnailUrl.isNullOrBlank()) {
+                                    setArtworkUri(thumbnailUrl.toUri())
+                                }
+                            }
                             .build()
                     )
                     .build()

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/components/LessonContentLayout.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/components/LessonContentLayout.kt
@@ -87,7 +87,8 @@ fun LessonContentLayout(
                     LaunchedEffect(key1 = contentItem.contentAudioUrl) {
                         viewModel.preparePlayer(
                             contentItem.contentAudioUrl,
-                            lesson.lessonTitle
+                            lesson.lessonTitle,
+                            contentItem.contentThumbnailUrl
                         )
                     }
 

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/domain/model/ui/UiLessonScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/domain/model/ui/UiLessonScreen.kt
@@ -14,4 +14,5 @@ data class UiLessonContent(
     val contentText : String = "" ,
     val contentImageUrl : String = "" ,
     val contentAudioUrl : String = "" ,
+    val contentThumbnailUrl : String = "" ,
 )

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/core/domain/model/api/ApiLessonResponse.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/core/domain/model/api/ApiLessonResponse.kt
@@ -20,5 +20,6 @@ data class ApiLessonContent(
     @SerialName("content_type") val contentType : String = "" ,
     @SerialName("content_text") val contentText : String = "" ,
     @SerialName("content_audio_url") val contentAudioUrl : String = "" ,
-    @SerialName("content_image_url") val contentImageUrl : String = ""
+    @SerialName("content_image_url") val contentImageUrl : String = "" ,
+    @SerialName("content_thumbnail_url") val contentThumbnailUrl : String = ""
 )

--- a/docs/lesson-api.md
+++ b/docs/lesson-api.md
@@ -1,0 +1,24 @@
+# Lesson API
+
+The lesson endpoint returns JSON describing a lesson. Each lesson contains an array of `lesson_content` objects. A content item of type `content_player` previously had the following structure:
+
+```json
+{
+  "content_id": "1",
+  "content_type": "content_player",
+  "content_audio_url": "https://.../tell_me_about_yourself.mp3"
+}
+```
+
+Starting with version 5.2.0, an optional `content_thumbnail_url` field may also be provided. This thumbnail is used as artwork for the Media3 notification during audio playback.
+
+```json
+{
+  "content_id": "1",
+  "content_type": "content_player",
+  "content_audio_url": "https://.../tell_me_about_yourself.mp3",
+  "content_thumbnail_url": "https://example.com/thumb.jpg"
+}
+```
+
+If omitted, the notification will display without artwork.


### PR DESCRIPTION
## Summary
- extend lesson API models with optional `content_thumbnail_url`
- map new field in `LessonRepositoryImpl`
- pass thumbnail to `preparePlayer` and set artwork in metadata
- document lesson API format with thumbnail field

## Testing
- `./gradlew build -x lint -x test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856aec7b3b4832db6956f6790694607