### PR TITLE
Fix lesson thumbnail mapping and add request timeout

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/data/LessonRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/data/LessonRepositoryImpl.kt
@@ -9,6 +9,7 @@ import com.d4rk.englishwithlidia.plus.core.utils.constants.api.ApiConstants
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
+import io.ktor.client.plugins.timeout
 import kotlinx.serialization.json.Json
 
 class LessonRepositoryImpl(
@@ -28,7 +29,9 @@ class LessonRepositoryImpl(
     override suspend fun getLesson(lessonId: String): UiLessonScreen {
         return runCatching {
             val url = "$baseUrl/api_get_$lessonId.json"
-            val jsonString = client.get(url).bodyAsText()
+            val jsonString = client.get(url) {
+                timeout { requestTimeoutMillis = 15000 }
+            }.bodyAsText()
 
             val lessons = jsonString.takeUnless { it.isBlank() }
                 ?.let { jsonParser.decodeFromString<ApiLessonResponse>(it) }
@@ -43,7 +46,7 @@ class LessonRepositoryImpl(
                                     contentText = networkContent.contentText,
                                     contentAudioUrl = networkContent.contentAudioUrl,
                                     contentImageUrl = networkContent.contentImageUrl,
-                                    contentThumbnailUrl = networkContent.contentImageUrl,
+                                    contentThumbnailUrl = networkContent.contentThumbnailUrl,
                                 )
                             },
                         ),

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/data/HomeRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/data/HomeRepositoryImpl.kt
@@ -9,6 +9,7 @@ import com.d4rk.englishwithlidia.plus.core.utils.constants.api.ApiConstants
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
+import io.ktor.client.plugins.timeout
 import kotlinx.serialization.json.Json
 
 class HomeRepositoryImpl(
@@ -27,7 +28,9 @@ class HomeRepositoryImpl(
 
     override suspend fun getHomeLessons(): UiHomeScreen {
         return runCatching {
-            val jsonString = client.get(baseUrl).bodyAsText()
+            val jsonString = client.get(baseUrl) {
+                timeout { requestTimeoutMillis = 15000 }
+            }.bodyAsText()
             val lessons = jsonString.takeUnless { it.isBlank() }
                 ?.let { jsonParser.decodeFromString<ApiHomeResponse>(it) }
                 ?.takeIf { it.data.isNotEmpty() }?.data?.mapNotNull { networkLesson ->


### PR DESCRIPTION
## Summary
- map lesson thumbnail URL correctly
- set request timeout for lesson and home lesson repository calls

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68583d0806dc832d8d0db0477e00c473