### PR TITLE
Refactor player logic into ActivityPlayer

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonActivity.kt
@@ -3,7 +3,7 @@ package com.d4rk.englishwithlidia.plus.app.lessons.details.ui
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.d4rk.englishwithlidia.plus.app.player.ActivityPlayer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -11,8 +11,8 @@ import androidx.compose.ui.Modifier
 import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
-class LessonActivity : AppCompatActivity() {
-    private val viewModel: LessonViewModel by viewModel()
+class LessonActivity : ActivityPlayer() {
+    override val viewModel: LessonViewModel by viewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonScreen.kt
@@ -38,12 +38,13 @@ fun LessonScreen(
                 NoDataScreen()
             },
             onSuccess = { lesson ->
-                LessonContentLayout(
-                    paddingValues = paddingValues,
-                    scrollState = scrollState,
-                    lesson = lesson,
-                    viewModel = viewModel,
-                )
+                    LessonContentLayout(
+                        paddingValues = paddingValues,
+                        scrollState = scrollState,
+                        lesson = lesson,
+                        activity = activity,
+                        viewModel = viewModel,
+                    )
             },
         )
     }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonViewModel.kt
@@ -1,15 +1,6 @@
 package com.d4rk.englishwithlidia.plus.app.lessons.details.ui
 
-import android.app.Application
-import android.content.ComponentName
-import android.content.Intent
-import androidx.core.content.ContextCompat
-import androidx.core.net.toUri
-import androidx.media3.common.MediaItem
-import androidx.media3.common.MediaMetadata
-import androidx.media3.common.Player
-import androidx.media3.session.MediaController
-import androidx.media3.session.SessionToken
+
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
@@ -20,52 +11,18 @@ import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.action.LessonAc
 import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.action.LessonEvent
 import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.usecases.GetLessonUseCase
 import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.ui.UiLessonScreen
-import com.d4rk.englishwithlidia.plus.core.utils.extensions.await
-import com.d4rk.englishwithlidia.plus.playback.AudioPlaybackService
-import com.google.common.util.concurrent.ListenableFuture
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
 
 class LessonViewModel(
-    private val application: Application,
     private val getLessonUseCase: GetLessonUseCase,
     private val dispatcherProvider: DispatcherProvider,
 ) : ScreenViewModel<UiLessonScreen, LessonEvent, LessonAction>(
     initialState = UiStateScreen(screenState = ScreenState.IsLoading(), data = UiLessonScreen())
 ) {
 
-    private var controllerFuture: ListenableFuture<MediaController>? = null
-    private var player: Player? = null
-    private var positionJob: Job? = null
-
     init {
-        launch {
-            val context = application
-            val intent = Intent(context, AudioPlaybackService::class.java)
-            ContextCompat.startForegroundService(context, intent)
-            val sessionToken = SessionToken(context, ComponentName(context, AudioPlaybackService::class.java))
-            controllerFuture = MediaController.Builder(context, sessionToken).buildAsync()
-            player = controllerFuture?.await()
-            player?.addListener(object : Player.Listener {
-                override fun onIsPlayingChanged(isPlaying: Boolean) {
-                    screenState.copyData { copy(isPlaying = isPlaying) }
-                    if (isPlaying) {
-                        startPositionUpdates()
-                    } else {
-                        positionJob?.cancel()
-                    }
-                }
-
-                override fun onPlaybackStateChanged(playbackState: Int) {
-                    if (playbackState == Player.STATE_READY) {
-                        val duration = player?.duration ?: 0L
-                        screenState.copyData { copy(playbackDuration = duration) }
-                    }
-                }
-            })
-        }
+        // No player initialization here. Player lifecycle is handled by ActivityPlayer.
     }
 
     fun getLesson(lessonId: String) {
@@ -84,81 +41,21 @@ class LessonViewModel(
         }
     }
 
-    fun preparePlayer(
-        audioUrl: String,
-        title: String,
-        thumbnailUrl: String? = null,
-        artist: String? = null,
-        albumTitle: String? = null,
-        genre: String? = null,
-        description: String? = null,
-        releaseYear: Int? = null
-    ) {
-        launch {
-            controllerFuture?.await()?.let { controller ->
-                val metadataBuilder = MediaMetadata.Builder()
-                    .setTitle(title)
-                    .setArtworkUri(thumbnailUrl?.toUri())
-                    .setArtist(artist)
-                    .setAlbumTitle(albumTitle)
-                    .setGenre(genre)
-                    .setDescription(description)
-                    .setReleaseYear(releaseYear)
-
-                val mediaItem = MediaItem.Builder()
-                    .setUri(audioUrl.toUri())
-                    .setMediaMetadata(metadataBuilder.build())
-                    .build()
-
-                controller.setMediaItem(mediaItem)
-                controller.prepare()
-                controller.playWhenReady = false
-            }
-        }
-    }
-
     override fun onEvent(event: LessonEvent) {
         when (event) {
             is LessonEvent.FetchLesson -> fetchLesson(event.lessonId)
         }
     }
 
-    fun playPause() {
-        player?.let { controller ->
-            if (controller.isPlaying) {
-                controller.pause()
-            } else {
-                controller.playWhenReady = true
-            }
-        }
+    fun updateIsPlaying(isPlaying: Boolean) {
+        screenState.copyData { copy(isPlaying = isPlaying) }
     }
 
-    fun seekTo(position: Long) {
-        player?.seekTo(position)
+    fun updatePlaybackDuration(duration: Long) {
+        screenState.copyData { copy(playbackDuration = duration) }
     }
 
-    private fun startPositionUpdates() {
-        positionJob?.cancel()
-        positionJob = launch(context = dispatcherProvider.default) {
-            while (true) {
-                withContext(dispatcherProvider.main) {
-                    val currentPosition = player?.currentPosition ?: 0L
-                    screenState.copyData { copy(playbackPosition = currentPosition) }
-
-                    if (player?.isPlaying != true) {
-                        positionJob?.cancel()
-                        return@withContext
-                    }
-                }
-                if (positionJob?.isCancelled == true) break
-                delay(timeMillis = 500)
-            }
-        }
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        positionJob?.cancel()
-        controllerFuture?.let { MediaController.releaseFuture(it) }
+    fun updatePlaybackPosition(position: Long) {
+        screenState.copyData { copy(playbackPosition = position) }
     }
 }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/components/LessonContentLayout.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/components/LessonContentLayout.kt
@@ -41,6 +41,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.ui.UiLessonScreen
 import com.d4rk.englishwithlidia.plus.app.lessons.details.ui.LessonViewModel
+import com.d4rk.englishwithlidia.plus.app.lessons.details.ui.LessonActivity
 import com.d4rk.englishwithlidia.plus.app.settings.display.theme.style.Colors
 import com.d4rk.englishwithlidia.plus.app.settings.display.theme.style.TextStyles
 import com.d4rk.englishwithlidia.plus.core.utils.constants.ui.lessons.LessonContentTypes
@@ -54,6 +55,7 @@ fun LessonContentLayout(
     paddingValues : PaddingValues ,
     scrollState : ScrollState ,
     lesson : UiLessonScreen ,
+    activity: LessonActivity ,
     viewModel : LessonViewModel ,
 ) {
     val bannerConfig: AdsConfig = koinInject()
@@ -91,7 +93,7 @@ fun LessonContentLayout(
                     val isPlaying = lesson.isPlaying
 
                     LaunchedEffect(key1 = contentItem.contentAudioUrl) {
-                        viewModel.preparePlayer(
+                        activity.preparePlayer(
                             audioUrl = contentItem.contentAudioUrl,
                             title = contentItem.contentTitle.ifBlank { lesson.lessonTitle },
                             thumbnailUrl = contentItem.contentThumbnailUrl,
@@ -103,9 +105,9 @@ fun LessonContentLayout(
                         )
                     }
 
-                    AudioCardView(onPlayClick = { viewModel.playPause() } ,
+                    AudioCardView(onPlayClick = { activity.playPause() } ,
                                   onSeekChange = { newPosition ->
-                                      viewModel.seekTo((newPosition * 1000).toLong())
+                                      activity.seekTo((newPosition * 1000).toLong())
                                   } ,
                                   sliderPosition = sliderPosition.toFloat() / 1000f ,
                                   playbackDuration = playbackDuration.toFloat() / 1000f ,

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/player/ActivityPlayer.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/player/ActivityPlayer.kt
@@ -1,0 +1,132 @@
+package com.d4rk.englishwithlidia.plus.app.player
+
+import android.content.ComponentName
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
+import androidx.lifecycle.lifecycleScope
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.Player
+import androidx.media3.session.MediaController
+import androidx.media3.session.SessionToken
+import com.d4rk.englishwithlidia.plus.app.lessons.details.ui.LessonViewModel
+import com.d4rk.englishwithlidia.plus.playback.AudioPlaybackService
+import com.google.common.util.concurrent.ListenableFuture
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.Dispatchers
+
+abstract class ActivityPlayer : AppCompatActivity() {
+
+    protected abstract val viewModel: LessonViewModel
+
+    private var controllerFuture: ListenableFuture<MediaController>? = null
+    protected var player: Player? = null
+    private var positionJob: Job? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val context = applicationContext
+        val intent = Intent(context, AudioPlaybackService::class.java)
+        ContextCompat.startForegroundService(context, intent)
+        val sessionToken = SessionToken(context, ComponentName(context, AudioPlaybackService::class.java))
+        controllerFuture = MediaController.Builder(context, sessionToken).buildAsync()
+        lifecycleScope.launch {
+            player = controllerFuture?.await()
+            player?.addListener(object : Player.Listener {
+                override fun onIsPlayingChanged(isPlaying: Boolean) {
+                    viewModel.updateIsPlaying(isPlaying)
+                    if (isPlaying) {
+                        startPositionUpdates()
+                    } else {
+                        positionJob?.cancel()
+                    }
+                }
+
+                override fun onPlaybackStateChanged(playbackState: Int) {
+                    if (playbackState == Player.STATE_READY) {
+                        val duration = player?.duration ?: 0L
+                        viewModel.updatePlaybackDuration(duration)
+                    }
+                }
+            })
+        }
+    }
+
+    protected fun preparePlayer(
+        audioUrl: String,
+        title: String,
+        thumbnailUrl: String? = null,
+        artist: String? = null,
+        albumTitle: String? = null,
+        genre: String? = null,
+        description: String? = null,
+        releaseYear: Int? = null
+    ) {
+        lifecycleScope.launch {
+            controllerFuture?.await()?.let { controller ->
+                val metadataBuilder = MediaMetadata.Builder()
+                    .setTitle(title)
+                    .setArtworkUri(thumbnailUrl?.toUri())
+                    .setArtist(artist)
+                    .setAlbumTitle(albumTitle)
+                    .setGenre(genre)
+                    .setDescription(description)
+                    .setReleaseYear(releaseYear)
+
+                val mediaItem = MediaItem.Builder()
+                    .setUri(audioUrl.toUri())
+                    .setMediaMetadata(metadataBuilder.build())
+                    .build()
+
+                controller.setMediaItem(mediaItem)
+                controller.prepare()
+                controller.playWhenReady = false
+            }
+        }
+    }
+
+    protected fun playPause() {
+        player?.let { controller ->
+            if (controller.isPlaying) {
+                controller.pause()
+            } else {
+                controller.playWhenReady = true
+            }
+        }
+    }
+
+    protected fun seekTo(position: Long) {
+        player?.seekTo(position)
+    }
+
+    private fun startPositionUpdates() {
+        positionJob?.cancel()
+        positionJob = lifecycleScope.launch(Dispatchers.Default) {
+            while (true) {
+                withContext(Dispatchers.Main) {
+                    val currentPosition = player?.currentPosition ?: 0L
+                    viewModel.updatePlaybackPosition(currentPosition)
+
+                    if (player?.isPlaying != true) {
+                        positionJob?.cancel()
+                        return@withContext
+                    }
+                }
+                if (positionJob?.isCancelled == true) break
+                delay(500)
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        positionJob?.cancel()
+        controllerFuture?.let { MediaController.releaseFuture(it) }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/core/di/modules/AppModule.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/core/di/modules/AppModule.kt
@@ -47,5 +47,5 @@ val appModule : Module = module {
 
     single<LessonRepository> { LessonRepositoryImpl(client = get()) }
     factory { GetLessonUseCase(repository = get()) }
-    viewModel { LessonViewModel(application = get(), getLessonUseCase = get(), dispatcherProvider = get()) }
+    viewModel { LessonViewModel(getLessonUseCase = get(), dispatcherProvider = get()) }
 }


### PR DESCRIPTION
## Summary
- introduce `ActivityPlayer` to manage `MediaController` setup
- convert `LessonActivity` to extend `ActivityPlayer`
- update `LessonContentLayout` and `LessonScreen` to use activity-based player APIs
- strip player code from `LessonViewModel` and expose update helpers
- adjust DI module for new `LessonViewModel` signature

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew testDebugUnitTest --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aab3356ec832db3105b22af21da76