### PR TITLE
Decouple ActivityPlayer from LessonViewModel

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonActivity.kt
@@ -12,7 +12,9 @@ import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class LessonActivity : ActivityPlayer() {
-    override val viewModel: LessonViewModel by viewModel()
+    override val playbackHandler: LessonViewModel by viewModel()
+    private val viewModel: LessonViewModel
+        get() = playbackHandler
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonViewModel.kt
@@ -13,13 +13,14 @@ import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.usecases.GetLes
 import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.ui.UiLessonScreen
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
+import com.d4rk.englishwithlidia.plus.app.player.PlaybackEventHandler
 
 class LessonViewModel(
     private val getLessonUseCase: GetLessonUseCase,
     private val dispatcherProvider: DispatcherProvider,
 ) : ScreenViewModel<UiLessonScreen, LessonEvent, LessonAction>(
     initialState = UiStateScreen(screenState = ScreenState.IsLoading(), data = UiLessonScreen())
-) {
+), PlaybackEventHandler {
 
     init {
         // No player initialization here. Player lifecycle is handled by ActivityPlayer.
@@ -47,15 +48,15 @@ class LessonViewModel(
         }
     }
 
-    fun updateIsPlaying(isPlaying: Boolean) {
+    override fun updateIsPlaying(isPlaying: Boolean) {
         screenState.copyData { copy(isPlaying = isPlaying) }
     }
 
-    fun updatePlaybackDuration(duration: Long) {
+    override fun updatePlaybackDuration(duration: Long) {
         screenState.copyData { copy(playbackDuration = duration) }
     }
 
-    fun updatePlaybackPosition(position: Long) {
+    override fun updatePlaybackPosition(position: Long) {
         screenState.copyData { copy(playbackPosition = position) }
     }
 }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/player/ActivityPlayer.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/player/ActivityPlayer.kt
@@ -12,7 +12,7 @@ import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
-import com.d4rk.englishwithlidia.plus.app.lessons.details.ui.LessonViewModel
+import com.d4rk.englishwithlidia.plus.app.player.PlaybackEventHandler
 import com.d4rk.englishwithlidia.plus.core.utils.extensions.await
 import com.d4rk.englishwithlidia.plus.playback.AudioPlaybackService
 import com.google.common.util.concurrent.ListenableFuture
@@ -24,7 +24,7 @@ import kotlinx.coroutines.Dispatchers
 
 abstract class ActivityPlayer : AppCompatActivity() {
 
-    protected abstract val viewModel: LessonViewModel
+    protected abstract val playbackHandler: PlaybackEventHandler
 
     private var controllerFuture: ListenableFuture<MediaController>? = null
     protected var player: Player? = null
@@ -41,7 +41,7 @@ abstract class ActivityPlayer : AppCompatActivity() {
             player = controllerFuture?.await()
             player?.addListener(object : Player.Listener {
                 override fun onIsPlayingChanged(isPlaying: Boolean) {
-                    viewModel.updateIsPlaying(isPlaying)
+                    playbackHandler.updateIsPlaying(isPlaying)
                     if (isPlaying) {
                         startPositionUpdates()
                     } else {
@@ -52,7 +52,7 @@ abstract class ActivityPlayer : AppCompatActivity() {
                 override fun onPlaybackStateChanged(playbackState: Int) {
                     if (playbackState == Player.STATE_READY) {
                         val duration = player?.duration ?: 0L
-                        viewModel.updatePlaybackDuration(duration)
+                        playbackHandler.updatePlaybackDuration(duration)
                     }
                 }
             })
@@ -112,7 +112,7 @@ abstract class ActivityPlayer : AppCompatActivity() {
             while (true) {
                 withContext(Dispatchers.Main) {
                     val currentPosition = player?.currentPosition ?: 0L
-                    viewModel.updatePlaybackPosition(currentPosition)
+                    playbackHandler.updatePlaybackPosition(currentPosition)
 
                     if (player?.isPlaying != true) {
                         positionJob?.cancel()

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/player/PlaybackEventHandler.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/player/PlaybackEventHandler.kt
@@ -1,0 +1,7 @@
+package com.d4rk.englishwithlidia.plus.app.player
+
+interface PlaybackEventHandler {
+    fun updateIsPlaying(isPlaying: Boolean)
+    fun updatePlaybackDuration(duration: Long)
+    fun updatePlaybackPosition(position: Long)
+}


### PR DESCRIPTION
## Summary
- add `PlaybackEventHandler` interface
- make `ActivityPlayer` depend on `PlaybackEventHandler`
- implement `PlaybackEventHandler` in `LessonViewModel`
- adapt `LessonActivity` to new interface

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1734a568832db0db2bb9b6ead8d5