### PR TITLE
Custom Media3 notification provider

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/playback/AudioPlaybackService.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/playback/AudioPlaybackService.kt
@@ -6,6 +6,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
+import com.d4rk.englishwithlidia.plus.playback.CustomNotificationProvider
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 
@@ -16,8 +17,16 @@ class AudioPlaybackService : MediaSessionService() {
         ExoPlayer.Builder(this).setAudioAttributes(audioAttributes , true).build()
     }
 
+    private val notificationProvider: CustomNotificationProvider by lazy {
+        CustomNotificationProvider(this)
+    }
+
     private val mediaSession : MediaSession by lazy {
-        MediaSession.Builder(this , player).setCallback(MediaSessionCallback()).build()
+        MediaSession.Builder(this , player)
+            .setCallback(MediaSessionCallback())
+            .setMediaNotificationProvider(notificationProvider)
+            .setMediaButtonResumptionEnabled(false)
+            .build()
     }
 
     override fun onCreate() {

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/playback/CustomNotificationProvider.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/playback/CustomNotificationProvider.kt
@@ -1,0 +1,18 @@
+package com.d4rk.englishwithlidia.plus.playback
+
+import android.content.Context
+import androidx.core.app.NotificationCompat
+import androidx.media3.session.DefaultMediaNotificationProvider
+import androidx.media3.session.MediaSession
+
+class CustomNotificationProvider(context: Context) : DefaultMediaNotificationProvider(context) {
+    override fun getMediaButtons(
+        session: MediaSession,
+        controllerInfo: MediaSession.ControllerInfo
+    ): List<NotificationCompat.Action> {
+        val actions = mutableListOf<NotificationCompat.Action>()
+        actions += createPlayPauseAction(session, controllerInfo)
+        actions += createSkipNextAction(session, controllerInfo)
+        return actions
+    }
+}


### PR DESCRIPTION
## Summary
- create `CustomNotificationProvider` without skip previous
- use the custom provider in `AudioPlaybackService`
- disable media button resumption

## Testing
- `./gradlew test --no-daemon --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860d16a2a7c832d9e84995a28c1d48e